### PR TITLE
Move run ssh commands

### DIFF
--- a/ocp_utilities/exceptions.py
+++ b/ocp_utilities/exceptions.py
@@ -4,3 +4,12 @@ class NodeNotReadyError(Exception):
 
 class NodeUnschedulableError(Exception):
     pass
+
+
+class CommandExecFailed(Exception):
+    def __init__(self, name, err=None):
+        self.name = name
+        self.err = f"Error: {err}" if err else ""
+
+    def __str__(self):
+        return f"Command: {self.name} - exec failed. {self.err}"

--- a/ocp_utilities/utils.py
+++ b/ocp_utilities/utils.py
@@ -1,5 +1,8 @@
 import subprocess
 
+from utilities.constants import TIMEOUT_30MIN
+
+from ocp_utilities.exceptions import CommandExecFailed
 from ocp_utilities.logger import get_logger
 
 
@@ -40,3 +43,41 @@ def run_command(command, verify_stderr=True, shell=False):
         return False, out_decoded, err_decoded
 
     return True, out_decoded, err_decoded
+
+
+def run_ssh_commands(
+    host, commands, get_pty=False, check_rc=True, timeout=TIMEOUT_30MIN
+):
+    """
+    Run commands via SSH
+
+    Args:
+        host (Host): rrmngmnt host to execute the commands from.
+        commands (list): List of multiple command lists [[cmd1, cmd2, cmd3]] or a list with a single command [cmd]
+            Examples:
+                 ["sudo", "reboot"], [["sleep", "5"], ["date"]]
+
+        get_pty (bool): get_pty parameter for remote session (equivalent to -t argument for ssh)
+        check_rc (bool): if True checks command return code and raises if rc != 0
+        timeout (int): ssh exec timeout
+
+    Returns:
+        list: List of commands output.
+
+    Raise:
+        CommandExecFailed: If command failed to execute.
+    """
+    results = []
+    commands = commands if isinstance(commands[0], list) else [commands]
+    with host.executor().session() as ssh_session:
+        for cmd in commands:
+            rc, out, err = ssh_session.run_cmd(
+                cmd=cmd, get_pty=get_pty, timeout=timeout
+            )
+            LOGGER.info(f"[SSH][{host.fqdn}] Executed: {' '.join(cmd)}")
+            if rc and check_rc:
+                raise CommandExecFailed(name=cmd, err=err)
+
+            results.append(out)
+
+    return results

--- a/ocp_utilities/utils.py
+++ b/ocp_utilities/utils.py
@@ -1,12 +1,12 @@
 import subprocess
 
-from utilities.constants import TIMEOUT_30MIN
-
 from ocp_utilities.exceptions import CommandExecFailed
 from ocp_utilities.logger import get_logger
 
 
 LOGGER = get_logger(name=__name__)
+
+TIMEOUT_30MIN = 30 * 60
 
 
 def run_command(command, verify_stderr=True, shell=False):


### PR DESCRIPTION
##### Short description: Move run_ssh_commands and associated CommandExecFailed to ocp_utilities/utils.py

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
