### PR TITLE
python remote debugger: get port from os env

### DIFF
--- a/ocp_utilities/debugger.py
+++ b/ocp_utilities/debugger.py
@@ -1,3 +1,5 @@
+import os
+
 from web_pdb import WebPdb
 
 
@@ -6,11 +8,14 @@ class WebDebugger(WebPdb):
     Project home:
         https://github.com/romanvm/python-web-pdb
 
-    port 1234 needs to be export in the docker container
+    port 1212 (default) needs to be export in the docker container
+    To set different port export os environment PYTHON_REMOTE_DEBUG_PORT
 
     Usage:
         pytest --pdbcls=ocp_utilities.debugger:WebDebugger --pdb
     """
 
     def __init__(self):
-        super().__init__(host="0.0.0.0", port=1234)
+        super().__init__(
+            host="0.0.0.0", port=int(os.environ.get("PYTHON_REMOTE_DEBUG_PORT", 1212))
+        )


### PR DESCRIPTION
Python remote debugger: allow setting port via OS env.
