### PR TITLE
Added pod validating method assert_pods_failed_or_pending to check pods health 

### DIFF
--- a/ocp_utilities/exceptions.py
+++ b/ocp_utilities/exceptions.py
@@ -6,6 +6,14 @@ class NodeUnschedulableError(Exception):
     pass
 
 
+class PodsHealthCheckError(Exception):
+    pass
+
+
+class PodsFailedOrPendingError(Exception):
+    pass
+
+
 class CommandExecFailed(Exception):
     def __init__(self, name, err=None):
         self.name = name

--- a/ocp_utilities/exceptions.py
+++ b/ocp_utilities/exceptions.py
@@ -6,10 +6,6 @@ class NodeUnschedulableError(Exception):
     pass
 
 
-class PodsHealthCheckError(Exception):
-    pass
-
-
 class PodsFailedOrPendingError(Exception):
     pass
 

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -53,9 +53,9 @@ def assert_nodes_schedulable(nodes):
         )
 
 
-def assert_pods_failed_or_pending(pods: list) -> None:
+def assert_pods_failed_or_pending(pods: list, namespace=None) -> None:
     """
-    Validates all pods and flag failed or pending pods
+    Validates all pods are not in failed nor pending phase
 
     Args:
          pods: List of pod objects
@@ -67,9 +67,14 @@ def assert_pods_failed_or_pending(pods: list) -> None:
 
     failed_or_pending_pods = []
     for pod in pods:
+        if namespace and pod.namespace != namespace:
+            continue
 
-        if pod.exists and pod.instance.status.phase in ["Failed", "Pending"]:
-            f"{pod.name} is {pod.instance.status.phase}"
+        if pod.exists and pod.instance.status.phase in [
+            pod.Status.PENDING,
+            pod.Status.FAILED,
+        ]:
+            failed_or_pending_pods.append(f"{pod.name} is {pod.instance.status.phase}")
 
     if failed_or_pending_pods:
         raise PodsFailedOrPendingError(

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -77,8 +77,9 @@ def assert_pods_failed_or_pending(pods: list) -> None:
     ]
 
     if failed_or_pending_pods:
+        failed_or_pending_pods_str = "\n\t".join(map(str, failed_or_pending_pods))
         raise PodsFailedOrPendingError(
-            f"The following pods are failed or pending: {failed_or_pending_pods}"
+            f"The following pods are failed or pending:\n\t{failed_or_pending_pods_str}",
         )
 
 

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -53,7 +53,7 @@ def assert_nodes_schedulable(nodes):
         )
 
 
-def assert_pods_failed_or_pending(pods: list, namespace=None) -> None:
+def assert_pods_failed_or_pending(pods: list) -> None:
     """
     Validates all pods are not in failed nor pending phase
 
@@ -65,16 +65,16 @@ def assert_pods_failed_or_pending(pods: list, namespace=None) -> None:
     """
     LOGGER.info("Verify all pods are not failed nor pending.")
 
-    failed_or_pending_pods = []
-    for pod in pods:
-        if namespace and pod.namespace != namespace:
-            continue
-
-        if pod.exists and pod.instance.status.phase in [
+    failed_or_pending_pods = [
+        (pod.name, pod.instance.status.phase)
+        for pod in pods
+        if pod.exists
+        and pod.instance.status.phase
+        in [
             pod.Status.PENDING,
             pod.Status.FAILED,
-        ]:
-            failed_or_pending_pods.append(f"{pod.name} is {pod.instance.status.phase}")
+        ]
+    ]
 
     if failed_or_pending_pods:
         raise PodsFailedOrPendingError(

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -63,7 +63,7 @@ def assert_pods_failed_or_pending(pods: list[Pod]) -> None:
          pods: List of pod objects
 
     Raises:
-        PodsFailedOrPendingError, if there are failed or pending pods
+        PodsFailedOrPendingError: if there are failed or pending pods
     """
     LOGGER.info("Verify all pods are not failed nor pending.")
 

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -4,7 +4,11 @@ from ocp_utilities.data_collector import (
     get_data_collector_base_dir,
     get_data_collector_dict,
 )
-from ocp_utilities.exceptions import NodeNotReadyError, NodeUnschedulableError
+from ocp_utilities.exceptions import (
+    NodeNotReadyError,
+    NodeUnschedulableError,
+    PodsFailedOrPendingError,
+)
 from ocp_utilities.logger import get_logger
 
 
@@ -46,6 +50,30 @@ def assert_nodes_schedulable(nodes):
     if unschedulable_nodes:
         raise NodeUnschedulableError(
             f"Following nodes are in unscheduled state: {unschedulable_nodes}"
+        )
+
+
+def assert_pods_failed_or_pending(pods: list) -> None:
+    """
+    Validates all pods and flag failed or pending pods
+
+    Args:
+         pods: List of pod objects
+
+    Raises:
+        PodsFailedOrPendingError, if there are failed or pending pods
+    """
+    LOGGER.info("Verify all pods are not failed nor pending.")
+
+    failed_or_pending_pods = []
+    for pod in pods:
+
+        if pod.exists and pod.instance.status.phase in ["Failed", "Pending"]:
+            f"{pod.name} is {pod.instance.status.phase}"
+
+    if failed_or_pending_pods:
+        raise PodsFailedOrPendingError(
+            f"The following pods are failed or pending: {failed_or_pending_pods}"
         )
 
 

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -65,16 +65,12 @@ def assert_pods_failed_or_pending(pods: list) -> None:
     """
     LOGGER.info("Verify all pods are not failed nor pending.")
 
-    failed_or_pending_pods = [
-        (pod.name, pod.instance.status.phase)
-        for pod in pods
-        if pod.exists
-        and pod.instance.status.phase
-        in [
-            pod.Status.PENDING,
-            pod.Status.FAILED,
-        ]
-    ]
+    failed_or_pending_pods = []
+    for pod in pods:
+        if pod.exists:
+            pod_status = pod.instance.status.phase
+            if pod_status in [pod.Status.PENDING, pod.Status.FAILED]:
+                failed_or_pending_pods.append((pod.name, pod_status))
 
     if failed_or_pending_pods:
         failed_or_pending_pods_str = "\n\t".join(map(str, failed_or_pending_pods))

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -1,5 +1,7 @@
 import importlib
 
+from ocp_resources.pod import Pod
+
 from ocp_utilities.data_collector import (
     get_data_collector_base_dir,
     get_data_collector_dict,
@@ -53,7 +55,7 @@ def assert_nodes_schedulable(nodes):
         )
 
 
-def assert_pods_failed_or_pending(pods: list) -> None:
+def assert_pods_failed_or_pending(pods: list[Pod]) -> None:
     """
     Validates all pods are not in failed nor pending phase
 


### PR DESCRIPTION
##### Short description:
Added a method and supporting exception (class) to validate pods that are neither `Failed` nor `Pending` 

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
