### PR TITLE
Assert nodes in healthy condition

### DIFF
--- a/ocp_utilities/exceptions.py
+++ b/ocp_utilities/exceptions.py
@@ -10,6 +10,10 @@ class PodsFailedOrPendingError(Exception):
     pass
 
 
+class NodesNotHealthyConditionError(Exception):
+    pass
+
+
 class CommandExecFailed(Exception):
     def __init__(self, name, err=None):
         self.name = name

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -118,10 +118,14 @@ def assert_pods_failed_or_pending(pods):
         )
 
 
+<<<<<<< HEAD
 def assert_nodes_in_healthy_condition(
     nodes,
     healthy_node_condition_type=None,
 ):
+=======
+def assert_nodes_in_healthy_condition(nodes, healthy_node_condition_type=None):
+>>>>>>> b2cb7be (Updated assert_nodes_in_healthy_condition - added argument to facilitate passing in a dictionary with the condition type/s and the respective healthy condition status)
     """
     Validates nodes are in a healthy condition.
     Nodes Ready condition is True and none of the following node conditions is True:
@@ -174,6 +178,7 @@ def assert_nodes_in_healthy_condition(
 =======
         MemoryPressure, PIDPressure, NetworkUnavailable condition is True
     """
+<<<<<<< HEAD
     LOGGER.info("Verify all nodes are in a healthy condition")
 <<<<<<< HEAD
     unhealthy_nodes_with_conditions = []
@@ -187,14 +192,21 @@ def assert_nodes_in_healthy_condition(
             ):
                 condition_type_list.append(condition.type)
 =======
+=======
+    LOGGER.info("Verify all nodes are in a healthy condition.")
+>>>>>>> b2cb7be (Updated assert_nodes_in_healthy_condition - added argument to facilitate passing in a dictionary with the condition type/s and the respective healthy condition status)
 
-    default_healthy_node_condition_type = dict(
-        DiskPressure=Node.Condition.Status.FALSE,
-        MemoryPressure=Node.Condition.Status.FALSE,
-        PIDPressure=Node.Condition.Status.FALSE,
-        NetworkUnavailable=Node.Condition.Status.FALSE,
-        Ready=Node.Condition.Status.TRUE,
-    )
+    default_healthy_node_condition_type = {
+        "DiskPressure": Node.Condition.Status.FALSE,
+        "MemoryPressure": Node.Condition.Status.FALSE,
+        "PIDPressure": Node.Condition.Status.FALSE,
+        "NetworkUnavailable": Node.Condition.Status.FALSE,
+        "Ready": Node.Condition.Status.TRUE,
+        "Disk": Node.Condition.Status.FALSE,
+    }
+
+    if not healthy_node_condition_type:
+        healthy_node_condition_type = default_healthy_node_condition_type
 
     unhealthy_nodes_with_conditions = {}
     for node in nodes:
@@ -202,8 +214,8 @@ def assert_nodes_in_healthy_condition(
         condition_type_list = [
             condition.type
             for condition in node.instance.status.conditions
-            if default_healthy_node_condition_type.get(condition.type)
-            != condition.status
+            if condition.type in healthy_node_condition_type
+            and healthy_node_condition_type.get(condition.type) != condition.status
         ]
 >>>>>>> a02c861 (Updated to include default healthy node condition types and status)
 

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -128,33 +128,38 @@ def assert_nodes_in_healthy_condition(
         - MemoryPressure
         - PIDPressure
         - NetworkUnavailable
+        - OutOfDisk
 
     Args:
          nodes(list): List of Node objects
 
          healthy_node_condition_type (dict):
-            Dictionary with condition type and the respective healthy condition status:
-            Example: {"DiskPressure": "False", ...}
+            Dictionary with condition type and the respective healthy condition
+                status: Example: {"DiskPressure": "False", ...}
 
     Raises:
-        NodesNotHealthyConditionError: if any nodes DiskPressure
-        MemoryPressure, PIDPressure, NetworkUnavailable, etc condition is True
+        NodesNotHealthyConditionError: if any nodes DiskPressure MemoryPressure,
+            PIDPressure, NetworkUnavailable, etc condition is True
     """
     LOGGER.info("Verify all nodes are in a healthy condition.")
 
     if not healthy_node_condition_type:
         healthy_node_condition_type = {
-            "Disk": Node.Condition.Status.FALSE,
+            "OutOfDisk": Node.Condition.Status.FALSE,
             "DiskPressure": Node.Condition.Status.FALSE,
             "MemoryPressure": Node.Condition.Status.FALSE,
             "NetworkUnavailable": Node.Condition.Status.FALSE,
             "PIDPressure": Node.Condition.Status.FALSE,
-            "Ready": Node.Condition.Status.TRUE,
+            Node.Condition.READY: Node.Condition.Status.TRUE,
         }
+
+    elif type(healthy_node_condition_type) != dict:
+        raise TypeError(
+            f"A dict is required but got type {type(healthy_node_condition_type)}"
+        )
 
     unhealthy_nodes_with_conditions = {}
     for node in nodes:
-
         unhealthy_condition_type_list = [
             condition.type
             for condition in node.instance.status.conditions

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -3,7 +3,6 @@ import json
 
 import kubernetes
 from ocp_resources.node import Node
-
 from ocp_wrapper_data_collector.data_collector import (
     get_data_collector_base_dir,
     get_data_collector_dict,
@@ -118,22 +117,10 @@ def assert_pods_failed_or_pending(pods):
         )
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 def assert_nodes_in_healthy_condition(
     nodes,
     healthy_node_condition_type=None,
 ):
-=======
-def assert_nodes_in_healthy_condition(nodes, healthy_node_condition_type=None):
->>>>>>> b2cb7be (Updated assert_nodes_in_healthy_condition - added argument to facilitate passing in a dictionary with the condition type/s and the respective healthy condition status)
-=======
-def assert_nodes_in_healthy_condition(
-    nodes,
-    bypass_check_if_kubelet_ready=True,
-    healthy_node_condition_type=None,
-):
->>>>>>> 649f14c (Added a default argument to bypass checking a node's conditions if node.kubelet_ready is True)
     """
     Validates nodes are in a healthy condition.
     Nodes Ready condition is True and none of the following node conditions is True:
@@ -145,19 +132,12 @@ def assert_nodes_in_healthy_condition(
     Args:
          nodes(list): List of Node objects
 
-         bypass_check_if_kubelet_ready:
-            Bypass checking a node's conditions if node.kubelet_ready is True
-
          healthy_node_condition_type (dict):
             Dictionary with condition type and the respective healthy condition status:
             Example: {"DiskPressure": "False", ...}
 
     Raises:
         NodesNotHealthyConditionError: if any nodes DiskPressure
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 649f14c (Added a default argument to bypass checking a node's conditions if node.kubelet_ready is True)
         MemoryPressure, PIDPressure, NetworkUnavailable, etc condition is True
     """
     LOGGER.info("Verify all nodes are in a healthy condition.")
@@ -189,69 +169,6 @@ def assert_nodes_in_healthy_condition(
         nodes_unhealthy_condition_error_str = json.dumps(
             unhealthy_nodes_with_conditions,
             indent=3,
-=======
-        MemoryPressure, PIDPressure, NetworkUnavailable condition is True
-    """
-<<<<<<< HEAD
-    LOGGER.info("Verify all nodes are in a healthy condition")
-<<<<<<< HEAD
-    unhealthy_nodes_with_conditions = []
-    for node in nodes:
-        node_conditions = node.instance.status.conditions
-        condition_type_list = []
-        for condition in node_conditions:
-            if (
-                condition.type != Node.Condition.READY
-                and condition.status == Node.Condition.Status.TRUE
-            ):
-                condition_type_list.append(condition.type)
-=======
-=======
-    LOGGER.info("Verify all nodes are in a healthy condition.")
->>>>>>> b2cb7be (Updated assert_nodes_in_healthy_condition - added argument to facilitate passing in a dictionary with the condition type/s and the respective healthy condition status)
-
-    default_healthy_node_condition_type = {
-        "Disk": Node.Condition.Status.FALSE,
-        "DiskPressure": Node.Condition.Status.FALSE,
-        "MemoryPressure": Node.Condition.Status.FALSE,
-        "NetworkUnavailable": Node.Condition.Status.FALSE,
-        "PIDPressure": Node.Condition.Status.FALSE,
-        "Ready": Node.Condition.Status.TRUE,
-    }
-
-    if not healthy_node_condition_type:
-        healthy_node_condition_type = default_healthy_node_condition_type
-
-    unhealthy_nodes_with_conditions = {}
-    for node in nodes:
-
-        if bypass_check_if_kubelet_ready and node.kubelet_ready:
-            continue
-
-        unhealthy_condition_type_list = [
-            condition.type
-            for condition in node.instance.status.conditions
-            if condition.type in healthy_node_condition_type
-            and healthy_node_condition_type[condition.type] != condition.status
-        ]
->>>>>>> a02c861 (Updated to include default healthy node condition types and status)
-
-<<<<<<< HEAD
-        if condition_type_list:
-<<<<<<< HEAD
-            unhealthy_nodes_with_conditions.append([node.name] + condition_type_list)
-=======
-            unhealthy_nodes_with_conditions[node.name] = condition_type_list
->>>>>>> 709084a (Remove redundant code)
-=======
-        if unhealthy_condition_type_list:
-            unhealthy_nodes_with_conditions[node.name] = unhealthy_condition_type_list
->>>>>>> 649f14c (Added a default argument to bypass checking a node's conditions if node.kubelet_ready is True)
-
-    if unhealthy_nodes_with_conditions:
-        nodes_unhealthy_condition_error_str = "\n\t".join(
-            map(str, unhealthy_nodes_with_conditions)
->>>>>>> 9c7af86 (Updated doc string)
         )
         raise NodesNotHealthyConditionError(
             f"Following are nodes with unhealthy condition/s:\n{nodes_unhealthy_condition_error_str}"

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -119,6 +119,7 @@ def assert_pods_failed_or_pending(pods):
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 def assert_nodes_in_healthy_condition(
     nodes,
     healthy_node_condition_type=None,
@@ -126,6 +127,13 @@ def assert_nodes_in_healthy_condition(
 =======
 def assert_nodes_in_healthy_condition(nodes, healthy_node_condition_type=None):
 >>>>>>> b2cb7be (Updated assert_nodes_in_healthy_condition - added argument to facilitate passing in a dictionary with the condition type/s and the respective healthy condition status)
+=======
+def assert_nodes_in_healthy_condition(
+    nodes,
+    bypass_check_if_kubelet_ready=True,
+    healthy_node_condition_type=None,
+):
+>>>>>>> 649f14c (Added a default argument to bypass checking a node's conditions if node.kubelet_ready is True)
     """
     Validates nodes are in a healthy condition.
     Nodes Ready condition is True and none of the following node conditions is True:
@@ -137,6 +145,9 @@ def assert_nodes_in_healthy_condition(nodes, healthy_node_condition_type=None):
     Args:
          nodes(list): List of Node objects
 
+         bypass_check_if_kubelet_ready:
+            Bypass checking a node's conditions if node.kubelet_ready is True
+
          healthy_node_condition_type (dict):
             Dictionary with condition type and the respective healthy condition status:
             Example: {"DiskPressure": "False", ...}
@@ -144,6 +155,9 @@ def assert_nodes_in_healthy_condition(nodes, healthy_node_condition_type=None):
     Raises:
         NodesNotHealthyConditionError: if any nodes DiskPressure
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 649f14c (Added a default argument to bypass checking a node's conditions if node.kubelet_ready is True)
         MemoryPressure, PIDPressure, NetworkUnavailable, etc condition is True
     """
     LOGGER.info("Verify all nodes are in a healthy condition.")
@@ -197,12 +211,12 @@ def assert_nodes_in_healthy_condition(nodes, healthy_node_condition_type=None):
 >>>>>>> b2cb7be (Updated assert_nodes_in_healthy_condition - added argument to facilitate passing in a dictionary with the condition type/s and the respective healthy condition status)
 
     default_healthy_node_condition_type = {
+        "Disk": Node.Condition.Status.FALSE,
         "DiskPressure": Node.Condition.Status.FALSE,
         "MemoryPressure": Node.Condition.Status.FALSE,
-        "PIDPressure": Node.Condition.Status.FALSE,
         "NetworkUnavailable": Node.Condition.Status.FALSE,
+        "PIDPressure": Node.Condition.Status.FALSE,
         "Ready": Node.Condition.Status.TRUE,
-        "Disk": Node.Condition.Status.FALSE,
     }
 
     if not healthy_node_condition_type:
@@ -211,20 +225,28 @@ def assert_nodes_in_healthy_condition(nodes, healthy_node_condition_type=None):
     unhealthy_nodes_with_conditions = {}
     for node in nodes:
 
-        condition_type_list = [
+        if bypass_check_if_kubelet_ready and node.kubelet_ready:
+            continue
+
+        unhealthy_condition_type_list = [
             condition.type
             for condition in node.instance.status.conditions
             if condition.type in healthy_node_condition_type
-            and healthy_node_condition_type.get(condition.type) != condition.status
+            and healthy_node_condition_type[condition.type] != condition.status
         ]
 >>>>>>> a02c861 (Updated to include default healthy node condition types and status)
 
+<<<<<<< HEAD
         if condition_type_list:
 <<<<<<< HEAD
             unhealthy_nodes_with_conditions.append([node.name] + condition_type_list)
 =======
             unhealthy_nodes_with_conditions[node.name] = condition_type_list
 >>>>>>> 709084a (Remove redundant code)
+=======
+        if unhealthy_condition_type_list:
+            unhealthy_nodes_with_conditions[node.name] = unhealthy_condition_type_list
+>>>>>>> 649f14c (Added a default argument to bypass checking a node's conditions if node.kubelet_ready is True)
 
     if unhealthy_nodes_with_conditions:
         nodes_unhealthy_condition_error_str = "\n\t".join(

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -135,7 +135,7 @@ def assert_nodes_in_healthy_condition(
 ):
     """
     Validates nodes are in a healthy condition.
-    Nodes Ready condition is True and none of the following node conditions is True:
+    Nodes Ready condition is True and the following node conditions are False:
         - DiskPressure
         - MemoryPressure
         - PIDPressure

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -187,7 +187,11 @@ def assert_nodes_in_healthy_condition(
                 condition_type_list.append(condition.type)
 
         if condition_type_list:
+<<<<<<< HEAD
             unhealthy_nodes_with_conditions.append([node.name] + condition_type_list)
+=======
+            unhealthy_nodes_with_conditions[node.name] = condition_type_list
+>>>>>>> 709084a (Remove redundant code)
 
     if unhealthy_nodes_with_conditions:
         nodes_unhealthy_condition_error_str = "\n\t".join(

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -165,7 +165,7 @@ def assert_nodes_in_healthy_condition(
             Node.Condition.READY: Node.Condition.Status.TRUE,
         }
 
-    elif type(healthy_node_condition_type) != dict:
+    if not isinstance(healthy_node_condition_type, dict):
         raise TypeError(
             f"A dict is required but got type {type(healthy_node_condition_type)}"
         )

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -175,6 +175,7 @@ def assert_nodes_in_healthy_condition(
         MemoryPressure, PIDPressure, NetworkUnavailable condition is True
     """
     LOGGER.info("Verify all nodes are in a healthy condition")
+<<<<<<< HEAD
     unhealthy_nodes_with_conditions = []
     for node in nodes:
         node_conditions = node.instance.status.conditions
@@ -185,6 +186,26 @@ def assert_nodes_in_healthy_condition(
                 and condition.status == Node.Condition.Status.TRUE
             ):
                 condition_type_list.append(condition.type)
+=======
+
+    default_healthy_node_condition_type = dict(
+        DiskPressure=Node.Condition.Status.FALSE,
+        MemoryPressure=Node.Condition.Status.FALSE,
+        PIDPressure=Node.Condition.Status.FALSE,
+        NetworkUnavailable=Node.Condition.Status.FALSE,
+        Ready=Node.Condition.Status.TRUE,
+    )
+
+    unhealthy_nodes_with_conditions = {}
+    for node in nodes:
+
+        condition_type_list = [
+            condition.type
+            for condition in node.instance.status.conditions
+            if default_healthy_node_condition_type.get(condition.type)
+            != condition.status
+        ]
+>>>>>>> a02c861 (Updated to include default healthy node condition types and status)
 
         if condition_type_list:
 <<<<<<< HEAD

--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -139,6 +139,7 @@ def assert_nodes_in_healthy_condition(
 
     Raises:
         NodesNotHealthyConditionError: if any nodes DiskPressure
+<<<<<<< HEAD
         MemoryPressure, PIDPressure, NetworkUnavailable, etc condition is True
     """
     LOGGER.info("Verify all nodes are in a healthy condition.")
@@ -170,6 +171,28 @@ def assert_nodes_in_healthy_condition(
         nodes_unhealthy_condition_error_str = json.dumps(
             unhealthy_nodes_with_conditions,
             indent=3,
+=======
+        MemoryPressure, PIDPressure, NetworkUnavailable condition is True
+    """
+    LOGGER.info("Verify all nodes are in a healthy condition")
+    unhealthy_nodes_with_conditions = []
+    for node in nodes:
+        node_conditions = node.instance.status.conditions
+        condition_type_list = []
+        for condition in node_conditions:
+            if (
+                condition.type != Node.Condition.READY
+                and condition.status == Node.Condition.Status.TRUE
+            ):
+                condition_type_list.append(condition.type)
+
+        if condition_type_list:
+            unhealthy_nodes_with_conditions.append([node.name] + condition_type_list)
+
+    if unhealthy_nodes_with_conditions:
+        nodes_unhealthy_condition_error_str = "\n\t".join(
+            map(str, unhealthy_nodes_with_conditions)
+>>>>>>> 9c7af86 (Updated doc string)
         )
         raise NodesNotHealthyConditionError(
             f"Following are nodes with unhealthy condition/s:\n{nodes_unhealthy_condition_error_str}"


### PR DESCRIPTION
Short description:
Verify nodes have no resource pressure (mem, CPU etc) or network issues. Implement as part of cluster sanity

More details:
Resources are consider under pressure if any of the following node conditions is True: DiskPressure. MemoryPressure, PIDPressure

https://www.datadoghq.com/blog/key-metrics-for-openshift-monitoring/#metric-to-alert-on-node-condition

