### PR TITLE
we need to set check=False to triage any must gather failure

### DIFF
--- a/ocp_utilities/must_gather.py
+++ b/ocp_utilities/must_gather.py
@@ -50,4 +50,4 @@ def run_must_gather(
     if flag_names:
         flag_string = "".join([f" --{flag_name}" for flag_name in flag_names])
         base_command += f" {flag_string}"
-    return run_command(command=shlex.split(base_command))[1]
+    return run_command(command=shlex.split(base_command), check=False)[1]


### PR DESCRIPTION
##### Short description: Without this we can't triage what is causing any must-gather command failure.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
