### PR TITLE
In run_command make check=False default

### DIFF
--- a/ocp_utilities/utils.py
+++ b/ocp_utilities/utils.py
@@ -16,7 +16,7 @@ def run_command(
     shell=False,
     timeout=None,
     capture_output=True,
-    check=True,
+    check=False,
     **kwargs,
 ):
     """
@@ -28,7 +28,7 @@ def run_command(
         shell (bool, default False): run subprocess with shell toggle
         timeout (int, optional): Command wait timeout
         capture_output (bool, default False): Capture command output
-        check (boot, default True):  If check is True and the exit code was non-zero, it raises a
+        check (boot, default False):  If check is True and the exit code was non-zero, it raises a
             CalledProcessError
 
     Returns:


### PR DESCRIPTION
If the command will fail and CalledProcessError will be raised, further code will be unreachable and the error will not be printed.

The default for subprocess.run is also check=False, so it looks reasonable to keep it this way.