### PR TITLE
metrics query results can be empty

### DIFF
--- a/ocp_utilities/monitoring.py
+++ b/ocp_utilities/monitoring.py
@@ -201,14 +201,14 @@ class Prometheus(object):
             func=self.query,
             query=query,
         )
+        sample = None
         try:
             for sample in sampler:
-                result = sample.get("data", {}).get("result")
-                if result and sample["status"] == "success":
-                    return result
+                if sample["status"] == "success":
+                    return sample.get("data", {}).get("result")
         except TimeoutExpiredError:
             LOGGER.error(
-                f"Failed to get successful status after executing query '{query}'"
+                f"Failed to get successful status after executing query '{query}'. Query result: {sample}"
             )
             raise
 


### PR DESCRIPTION
##### Short description: query_sampler should return the results as long as status of the query is successful

##### More details:
{'status': 'success', 'data': {'resultType': 'vector', 'result': []}} this is a valid metrics query result and should not result in a timeout exception
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
