### PR TITLE
Get kubeconfig config file from os env if not passed to get_client

### DIFF
--- a/ocp_utilities/infra.py
+++ b/ocp_utilities/infra.py
@@ -49,7 +49,6 @@ def get_client(config_file=None, config_dict=None, context=None, **kwargs):
         DynamicClient: a kubernetes client.
     """
     # Ref: https://github.com/kubernetes-client/python/blob/v26.1.0/kubernetes/base/config/kube_config.py
-
     if config_dict:
         return kubernetes.dynamic.DynamicClient(
             client=kubernetes.config.new_client_from_config_dict(config_dict=config_dict, context=context, **kwargs)


### PR DESCRIPTION
  kubernetes.config.kube_config.load_kube_config sets KUBE_CONFIG_DEFAULT_LOCATION during module import.
  If `KUBECONFIG` environment variable is set via code, the `KUBE_CONFIG_DEFAULT_LOCATION` will be None since
  is populated during import which comes before setting the variable in code.