### PR TITLE
wait_for_firing_alert_sampler(..) to honor timeout

### DIFF
--- a/ocp_utilities/monitoring.py
+++ b/ocp_utilities/monitoring.py
@@ -152,7 +152,7 @@ class Prometheus(object):
         Raise:
              TimeoutExpiredError: if alert is not fired before wait_timeout
         """
-        return self.wait_for_alert_by_state_sampler(alert_name=alert_name)
+        return self.wait_for_alert_by_state_sampler(alert_name=alert_name, timeout=timeout)
 
     def get_scrape_interval(self):
         """


### PR DESCRIPTION
##### Short description:
The method _monitoring.wait_for_firing_alert_sampler()_ doesn't honor timeout, when the timeout value is a different custom value other than 10 minutes. Because of this behavior, few observability test cases that makes use of this method with custom timeout values like 15 mins fails as the method could only wait for maximum of 10 minutes

Now this issue is fixed by passing the custom timeout value to the other method that it calls.

##### More details:
Fixes a simple issue

##### What this PR does / why we need it:
Now the method passes the timeout value to the other method that it calls

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
