### PR TITLE
Support global operator installation

### DIFF
--- a/ocp_utilities/operators.py
+++ b/ocp_utilities/operators.py
@@ -221,13 +221,15 @@ def install_operator(
             if not ns.exists:
                 ns.deploy(wait=True)
 
-        if operator_namespace != "openshift-operators":
-            OperatorGroup(
-                client=admin_client,
-                name=name,
-                namespace=operator_namespace,
-                target_namespaces=target_namespaces or [operator_namespace],
-            ).deploy(wait=True)
+        operator_group_name = "global-operators" if operator_namespace == "openshift-operators" else name
+        operator_group = OperatorGroup(
+            client=admin_client,
+            name=operator_group_name,
+            namespace=operator_namespace,
+            target_namespaces=target_namespaces,
+        )
+        if not operator_group.exists:
+            operator_group.deploy(wait=True)
 
         subscription = Subscription(
             client=admin_client,

--- a/ocp_utilities/operators.py
+++ b/ocp_utilities/operators.py
@@ -221,12 +221,13 @@ def install_operator(
             if not ns.exists:
                 ns.deploy(wait=True)
 
-        OperatorGroup(
-            client=admin_client,
-            name=name,
-            namespace=operator_namespace,
-            target_namespaces=target_namespaces,
-        ).deploy(wait=True)
+        if operator_namespace != "openshift-operators":
+            OperatorGroup(
+                client=admin_client,
+                name=name,
+                namespace=operator_namespace,
+                target_namespaces=target_namespaces or [operator_namespace],
+            ).deploy(wait=True)
 
         subscription = Subscription(
             client=admin_client,


### PR DESCRIPTION
##### Short description: Support global operator install when `operator_namespace` is  `openshift-operators` 

##### More details: When operator installs in this ns `openshift-operators`  since OperatorGroup already exists in this namespace so we don't need to create this, and skip it.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
