### PR TITLE
prometheus calls should be made with explicitly generated token

### DIFF
--- a/ocp_utilities/monitoring.py
+++ b/ocp_utilities/monitoring.py
@@ -44,12 +44,12 @@ class Prometheus(object):
         Args:
             bearer_token (str, Required): Used for query OAuth with API endpoint, this needs to be created via oc
             create token command
+             Example to create prometheus token: oc create token prometheus-k8s -n openshift-monitoring --duration=600s
+                This would create a token for prometheus calls, that would expire in 600 seconds
             namespace (str): Prometheus API resource namespace
             resource_name (str): Prometheus API resource name
             client (DynamicClient): Admin client resource
             verify_ssl (bool): Perform SSL verification on query
-        Example to create prometheus token: oc create token prometheus-k8s -n openshift-monitoring --duration=600s
-                This would create a token for prometheus calls, that would expire in 600 seconds
         """
         self.namespace = namespace
         self.resource_name = resource_name
@@ -57,9 +57,6 @@ class Prometheus(object):
         self.api_v1 = "/api/v1"
         self.verify_ssl = verify_ssl
         self.bearer_token = bearer_token
-
-        if not self.bearer_token:
-            raise ValueError("Prometheus token is required.")
 
         self.api_url = self._get_route()
         self.headers = {"Authorization": f"Bearer {self.bearer_token}"}

--- a/ocp_utilities/monitoring.py
+++ b/ocp_utilities/monitoring.py
@@ -46,8 +46,10 @@ class Prometheus(object):
             resource_name (str): Prometheus API resource name
             client (DynamicClient): Admin client resource
             verify_ssl (bool): Perform SSL verification on query
-            bearer_token (str): Used for query OAuth with API endpoint, this needs to be created via oc create token command
-                example: oc create token <resource_name> -n <namespace> --duration=<number>s
+            bearer_token (str, Required): Used for query OAuth with API endpoint, this needs to be created via oc
+            create token command
+                example: oc create token prometheus-k8s -n openshift-monitoring --duration=600s
+                This would create a token for prometheus calls, that would expire in 600 seconds
         """
         self.namespace = namespace
         self.resource_name = resource_name
@@ -67,8 +69,7 @@ class Prometheus(object):
         return f"https://{route}"
 
     def _get_headers(self) -> Dict[str, str]:
-        """Uses the Prometheus serviceaccount to get an access token for OAuth if not given"""
-        LOGGER.info("Setting Prometheus headers and Obtaining OAuth token")
+        LOGGER.info("Setting authorization headers for prometheus call")
         return {"Authorization": f"Bearer {self.bearer_token}"}
 
     def _get_response(self, query: str) -> Dict[str, Any]:

--- a/ocp_utilities/monitoring.py
+++ b/ocp_utilities/monitoring.py
@@ -7,8 +7,6 @@ from typing import Any, Dict, List
 import requests
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.route import Route
-from ocp_resources.secret import Secret
-from ocp_resources.service_account import ServiceAccount
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 from simple_logger.logger import get_logger
 
@@ -48,7 +46,8 @@ class Prometheus(object):
             resource_name (str): Prometheus API resource name
             client (DynamicClient): Admin client resource
             verify_ssl (bool): Perform SSL verification on query
-            bearer_token (str): Used for query OAuth with API endpoint
+            bearer_token (str): Used for query OAuth with API endpoint, this needs to be created via oc create token command
+                example: oc create token <resource_name> -n <namespace> --duration=<number>s
         """
         self.namespace = namespace
         self.resource_name = resource_name
@@ -70,26 +69,7 @@ class Prometheus(object):
     def _get_headers(self) -> Dict[str, str]:
         """Uses the Prometheus serviceaccount to get an access token for OAuth if not given"""
         LOGGER.info("Setting Prometheus headers and Obtaining OAuth token")
-
-        if not self.bearer_token:
-            secret = self._get_resource_secret()
-            self.bearer_token = secret.instance.metadata.annotations["openshift.io/token-secret.value"]
-
         return {"Authorization": f"Bearer {self.bearer_token}"}
-
-    def _get_service_account(self) -> ServiceAccount:
-        """get service account  for the given namespace and resource"""
-
-        return ServiceAccount(namespace=self.namespace, name=self.resource_name, client=self.client)
-
-    def _get_resource_secret(self) -> Secret:
-        """secret for the service account extracted"""
-        resource_sa = self._get_service_account()
-        return Secret(
-            namespace=self.namespace,
-            name=resource_sa.instance.imagePullSecrets[0].name,
-            client=self.client,
-        )
 
     def _get_response(self, query: str) -> Dict[str, Any]:
         response = requests.get(f"{self.api_url}{query}", headers=self.headers, verify=self.verify_ssl)


### PR DESCRIPTION
##### Short description: 
Cluster monitoring operator asks the apiserver to deploy https://github.com/openshift/cluster-monitoring-operator/blob/release-4.17/assets/prometheus-k8s/service-account.yaml. openshift-monitoring team recommends generating specific tokens and using it for prometheus query, instead of assuming imagePullSecrets would always be there. In CNV we found this field not to be reliable, specially for post upgrade scenarios. 

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
