### PR TITLE
[MSINTEROP-1243] Add mirror for registry.stage.redhat.io to ICSP for operator install

### DIFF
--- a/ocp_utilities/operators.py
+++ b/ocp_utilities/operators.py
@@ -371,6 +371,10 @@ def create_catalog_source_for_iib_install(
             "source": f"registry.redhat.io/{brew_image_repo}",
             "mirrors": [f"{brew_registry}/{brew_image_repo}"],
         },
+        {
+            "source": f"registry.stage.redhat.io/{brew_image_repo}",
+            "mirrors": [f"{brew_registry}/{brew_image_repo}"],
+        },
     ]
 
     if validating_webhook_configuration.exists:


### PR DESCRIPTION
##### Short description:
Adds a mirror to the ICSP created for operator install.

##### More details:
We are encountering issues installing an IIB image being stored in `registry.stage.redhat.io`. Adding this mirror seems to resolve the error we encounter.

[Here](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-pipelines-release-tests-release-v1.15-openshift-pipelines-p2p-rosa-classic-openshift-pipelines-serverless-rosa-classic-416-iib/1823500259423162368) is an example of the error that occurs.
