### PR TITLE
Update stage ICSP mirror

### DIFF
--- a/ocp_utilities/operators.py
+++ b/ocp_utilities/operators.py
@@ -373,7 +373,7 @@ def create_catalog_source_for_iib_install(
         },
         {
             "source": "registry.stage.redhat.io",
-            "mirrors": [f"{brew_registry}"],
+            "mirrors": [brew_registry],
         },
     ]
 

--- a/ocp_utilities/operators.py
+++ b/ocp_utilities/operators.py
@@ -372,8 +372,8 @@ def create_catalog_source_for_iib_install(
             "mirrors": [f"{brew_registry}/{brew_image_repo}"],
         },
         {
-            "source": f"registry.stage.redhat.io/{brew_image_repo}",
-            "mirrors": [f"{brew_registry}/{brew_image_repo}"],
+            "source": "registry.stage.redhat.io",
+            "mirrors": [f"{brew_registry}"],
         },
     ]
 


### PR DESCRIPTION
##### Short description:
I added this mirror and shortly after relized the `/{brew_image_repo}` at the end of the mirror addresses is not needed and breaks the functionality. My apologies, I forgot to remove that before pushing the changes last week.
