### PR TITLE
Add option to uninstall_operator to avoid ns cleanup

### DIFF
--- a/ocp_utilities/operators.py
+++ b/ocp_utilities/operators.py
@@ -1,4 +1,3 @@
-from itertools import chain
 from pprint import pformat
 from typing import Any, Dict, List, Optional
 
@@ -6,16 +5,12 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.catalog_source import CatalogSource
 from ocp_resources.cluster_service_version import ClusterServiceVersion
-from ocp_resources.configmap import ConfigMap
-from ocp_resources.deployment import Deployment
 from ocp_resources.image_content_source_policy import ImageContentSourcePolicy
 from ocp_resources.installplan import InstallPlan
 from ocp_resources.namespace import Namespace
 from ocp_resources.operator import Operator
 from ocp_resources.operator_group import OperatorGroup
-from ocp_resources.resource import ResourceEditor, NamespacedResource, Resource
-from ocp_resources.secret import Secret
-from ocp_resources.service import Service
+from ocp_resources.resource import ResourceEditor
 from ocp_resources.subscription import Subscription
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 from ocp_resources.validating_webhook_config import ValidatingWebhookConfiguration


### PR DESCRIPTION
##### Short description:
Adds an option to uninstall_operator method to avoid complete ns cleanup

##### More details:
Currently when we uninstall an operator using the `uninstall_operator` function, we clean up the operator namespace completely. This is a problem if the operator is installed in `openshift-operators`, as it will delete any other cluster-scoped operator installed. This PR adds an option to avoid this behavior and just clean up the specific target operator, without affecting the previous behavior.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
