### PR TITLE
feat: add str as possible type of verify_ssl in Prometheus class

### DIFF
--- a/ocp_utilities/monitoring.py
+++ b/ocp_utilities/monitoring.py
@@ -38,7 +38,7 @@ class Prometheus(object):
         namespace: str = "openshift-monitoring",
         resource_name: str = "prometheus-k8s",
         client: DynamicClient = None,
-        verify_ssl: bool = True,
+        verify_ssl: bool | str = True,
     ) -> None:
         """
         Args:
@@ -49,7 +49,7 @@ class Prometheus(object):
             namespace (str): Prometheus API resource namespace
             resource_name (str): Prometheus API resource name
             client (DynamicClient): Admin client resource
-            verify_ssl (bool): Perform SSL verification on query
+            verify_ssl (bool | str): Perform SSL verification on query
         """
         self.namespace = namespace
         self.resource_name = resource_name

--- a/ocp_utilities/monitoring.py
+++ b/ocp_utilities/monitoring.py
@@ -49,7 +49,8 @@ class Prometheus(object):
             namespace (str): Prometheus API resource namespace
             resource_name (str): Prometheus API resource name
             client (DynamicClient): Admin client resource
-            verify_ssl (bool | str): Perform SSL verification on query
+            verify_ssl (bool | str): Whether to perform SSL verification on query,
+            if so, path to a CA_BUNDLE file or directory with certificates of trusted CAs
         """
         self.namespace = namespace
         self.resource_name = resource_name


### PR DESCRIPTION
##### Short description:
requests.get can get a False bool when not verifying ssl, or a string containing the cert path when verifying ssl, currently we can pass the string, but we get a typing warning.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify that SSL verification can now accept either a boolean or a file path for trusted certificates.

- **Refactor**
  - Enhanced SSL verification parameter to support both boolean values and file paths for greater flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->